### PR TITLE
Bumping to Kotlin 1.3.21. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.ktVersion = "1.2.70"
+  ext.ktVersion = "1.3.21"
   repositories { jcenter() }
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$ktVersion"

--- a/gradle-plugin/src/main/kotlin/debuglog/DebugLogGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/debuglog/DebugLogGradleSubplugin.kt
@@ -3,6 +3,7 @@ package debuglog
 import com.google.auto.service.AutoService
 import org.gradle.api.Project
 import org.gradle.api.tasks.compile.AbstractCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinGradleSubplugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
@@ -20,7 +21,7 @@ class DebugLogGradleSubplugin : KotlinGradleSubplugin<AbstractCompile> {
       javaCompile: AbstractCompile?,
       variantData: Any?,
       androidProjectHandler: Any?,
-      kotlinCompilation: KotlinCompilation?
+      kotlinCompilation: KotlinCompilation<KotlinCommonOptions>?
   ): List<SubpluginOption> {
     val extension = project.extensions.findByType(DebugLogGradleExtension::class.java)
         ?: DebugLogGradleExtension()

--- a/kotlin-plugin/src/main/kotlin/debuglog/plugin/DebugLogCommandLineProcessor.kt
+++ b/kotlin-plugin/src/main/kotlin/debuglog/plugin/DebugLogCommandLineProcessor.kt
@@ -1,6 +1,7 @@
 package debuglog.plugin
 
 import com.google.auto.service.AutoService
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.config.CompilerConfiguration
@@ -19,24 +20,24 @@ class DebugLogCommandLineProcessor : CommandLineProcessor {
    */
   override val pluginOptions: Collection<CliOption> = listOf(
       CliOption(
-          name = "enabled", valueDescription = "<true|false>",
+          optionName = "enabled", valueDescription = "<true|false>",
           description = "whether to enable the debuglog plugin or not"
       ),
       CliOption(
-          name = "debugLogAnnotation", valueDescription = "<fqname>",
+          optionName = "debugLogAnnotation", valueDescription = "<fqname>",
           description = "fully qualified name of the annotation(s) to use as debug-log",
           required = true, allowMultipleOccurrences = true
       )
   )
 
   override fun processOption(
-      option: CliOption,
-      value: String,
-      configuration: CompilerConfiguration
-  ) = when (option.name) {
+          option: AbstractCliOption,
+          value: String,
+          configuration: CompilerConfiguration
+  ) = when (option.optionName) {
     "enabled" -> configuration.put(KEY_ENABLED, value.toBoolean())
     "debugLogAnnotation" -> configuration.appendList(KEY_ANNOTATIONS, value)
-    else -> error("Unexpected config option ${option.name}")
+    else -> error("Unexpected config option ${option.optionName}")
   }
 }
 


### PR DESCRIPTION
* The `name` field in CliOption is now named `optionName`.
* Moving to `processOption` that takes AbstractCliOption, since the one that takes CliOption is deprecated.